### PR TITLE
Add repository field to play nice with others

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,9 @@
     "request": "2.12.0",
     "log4js": "0.5.6",
     "underscore": "~1.4.4"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/shutterstock/armrest.git"
+  },
 }


### PR DESCRIPTION
:rainbow: Side note, [npmjs](https://npmjs.org/package/armrest) still lists armrest at `version 1.0.1`
