### PR TITLE
Clone query object when present.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ var request = require('request');
 var querystring = require('querystring');
 var url = require('url');
 var log4js = require('log4js');
-var und = require('underscore');
+var und = require('lodash');
 
 /*
  * Default content serializer for HTTP requests and responses
@@ -75,7 +75,7 @@ var Client = function(args) {
 		args.headers = args.headers || {};
 		und.defaults(args.headers, this.headers, requestDefaults.headers);
 
-		var query = args.query || {};
+		var query = und.cloneDeep(args.query) || {};
 		var requestBody = args.body || {};
 
 		// divvy up request parameters according to convention

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "request": "2.12.0",
     "log4js": "0.5.6",
-    "underscore": "~1.4.4"
+    "lodash": "~2.2.1"
   },
   "repository": {
     "type": "git",

--- a/tests/params.js
+++ b/tests/params.js
@@ -79,6 +79,19 @@ exports.interpolatePostQuery = function(test) {
 	});
 };
 
+exports.queryMutation = function (test) {
+	var query = { level: 'level', structure: 'structure' };
+
+	client.get({
+		url: '/multi/:level/:structure',
+		query: query,
+		success: function (data) {
+			test.deepEqual(query, { level: 'level', structure: 'structure' }, 'query object is not modified');
+			test.done();
+		}
+	});
+};
+
 exports.colons = function(test) {
 	client.get({
 		url: '/echo-query',


### PR DESCRIPTION
Fixes #6.
I replaced underscore with lodash which has a nice `cloneDeep` method. The API is still the same as underscore so all tests pass.
